### PR TITLE
Add French spelling locale

### DIFF
--- a/locale/fr-fr/Spell.intent
+++ b/locale/fr-fr/Spell.intent
@@ -1,0 +1,9 @@
+épelle {word}
+épelle le mot {word}
+peux-tu épeler {word}
+peux-tu épeler le mot {word}
+donne-moi l'orthographe de {word}
+quelle est l'orthographe de {word}
+comment s'écrit {word}
+comment épelle-t-on {word}
+orthographe de {word}

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,9 +1,9 @@
 {
-  "name": "Skill d'orthographe",
+  "name": "Orthographe",
   "examples": [
     "Comment s'écrit ornithorynque ?",
     "Épelle omnipotence",
     "Quelle est l'orthographe de bureaucratie ?",
-    "Épelle succotash"
+    "Épelle anticonstitutionnellement"
   ]
 }

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,9 @@
+{
+  "name": "Skill d'orthographe",
+  "examples": [
+    "Comment s'écrit ornithorynque ?",
+    "Épelle omnipotence",
+    "Quelle est l'orthographe de bureaucratie ?",
+    "Épelle succotash"
+  ]
+}

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,0 +1,9 @@
+{
+  "Spell.intent": [
+    "(épelle|épelle le mot|peux-tu épeler|peux-tu épeler le mot) {word}",
+    "(donne-moi|quelle est) l'orthographe de {word}",
+    "comment s'écrit {word}",
+    "comment épelle-t-on {word}",
+    "orthographe de {word}"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the missing French spelling intent examples and localized skill metadata
- keep the phrasing natural for spoken spelling requests

## Validation
- verified fr-fr file coverage against locale/en-us
- validated locale/fr-fr/skill.json parses as JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added French language support for spelling and orthography inquiries, enabling French-speaking users to request word spellings through multiple natural language variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->